### PR TITLE
Freebusy API の仕様微修正

### DIFF
--- a/spec/paths/schedules/schedule_free_busy.yaml
+++ b/spec/paths/schedules/schedule_free_busy.yaml
@@ -24,7 +24,7 @@ get:
       description: "終了時刻"
       example: "2021-09-02T12:00:00+09:00"
     - in: query
-      name: user_ids
+      name: user_ids[]
       required: true
       schema:
         type: array


### PR DESCRIPTION
インプットパラメータの想定が配列の場合、Djangoの待ち受け方は `user_ids[] `となるので、その点のみ修正しました。