### PR TITLE
CRM-5082: スケジュール作成APIで活動項目を指定できるようにする

### DIFF
--- a/spec/components/schemas/schedules/schedule.yaml
+++ b/spec/components/schemas/schedules/schedule.yaml
@@ -38,6 +38,10 @@ allOf:
         type: string
         description: "予定色コード"
         example: "#453590"
+      activity_item_id:
+        type: number
+        description: "活動項目ID"
+        example: 123
       update_range:
         type: number
         example: 1


### PR DESCRIPTION
スケジュール作成APIのパラメータに活動項目IDを追加しました。